### PR TITLE
Make changes to the custom request template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-openapi-codegen",
-    "version": "0.1.23",
+    "version": "0.1.24",
     "description": "Library that generates Typescript clients based on the OpenAPI specification. It bases on openapi-typescript-codegen",
     "author": "Alexey Zverev",
     "homepage": "https://github.com/ozonophore/openapi-codegen.git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ export async function generate({
             const client = parseV2(CONTEXT, openApi);
             const clientFinal = postProcessClient(client);
             if (!write) break;
-            await writeClient(clientFinal, templates, output, httpClient, useOptions, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas, clean, request);
+            await writeClient({ client: clientFinal, templates, output, httpClient, useOptions, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas, clean, request });
             break;
         }
 
@@ -80,7 +80,7 @@ export async function generate({
             const client = parseV3(CONTEXT, openApi);
             const clientFinal = postProcessClient(client);
             if (!write) break;
-            await writeClient(clientFinal, templates, output, httpClient, useOptions, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas, clean, request);
+            await writeClient({ client: clientFinal, templates, output, httpClient, useOptions, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas, clean, request });
             break;
         }
     }

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -36,7 +36,11 @@ export class {{{name}}} {
      * @throws ApiError
      */
     public static async {{{name}}}({{>parameters}}): Promise<{{>result}}> {
+        {{#if @root.useCustomRequest}}
+        return await __request<{{>result}}>({
+        {{else}}
         const result = await __request({
+        {{/if}}
             method: '{{{method}}}',
             path: `{{{path}}}`,
             {{#if parametersCookie}}
@@ -83,8 +87,12 @@ export class {{{name}}} {
                 {{/each}}
             },
             {{/if}}
+        {{#if @root.useCustomRequest}}
+        }).then((resp) => resp);
+        {{else}}
         });
         return result.body;
+        {{/if}}
     }
 
     {{/each}}

--- a/src/utils/writeClient.spec.ts
+++ b/src/utils/writeClient.spec.ts
@@ -31,7 +31,19 @@ describe('writeClient', () => {
             },
         };
 
-        await writeClient(client, templates, './dist', HttpClient.FETCH, false, false, true, true, true, true, true);
+        await writeClient({
+            client,
+            templates,
+            output: './dist',
+            httpClient: HttpClient.FETCH,
+            useOptions: false,
+            useUnionTypes: false,
+            exportCore: true,
+            exportServices: true,
+            exportModels: true,
+            exportSchemas: true,
+            clean: true,
+        });
 
         expect(rmdir).toBeCalled();
         expect(mkdir).toBeCalled();

--- a/src/utils/writeClientCore.spec.ts
+++ b/src/utils/writeClientCore.spec.ts
@@ -31,7 +31,7 @@ describe('writeClientCore', () => {
             },
         };
 
-        await writeClientCore(client, templates, '/', HttpClient.FETCH);
+        await writeClientCore({ client, templates, outputPath: '/', httpClient: HttpClient.FETCH });
 
         expect(writeFile).toBeCalledWith('/OpenAPI.ts', 'settings');
         expect(writeFile).toBeCalledWith('/ApiError.ts', 'apiError');

--- a/src/utils/writeClientCore.ts
+++ b/src/utils/writeClientCore.ts
@@ -6,6 +6,21 @@ import { copyFile, exists, writeFile } from './fileSystem';
 import { Templates } from './registerHandlebarTemplates';
 
 /**
+ * @param client Client object, containing, models, schemas and services
+ * @param templates The loaded handlebar templates
+ * @param outputPath Directory to write the generated files to
+ * @param httpClient The selected httpClient (fetch, xhr or node)
+ * @param request: Path to custom request file
+ */
+interface IWriteClientCore {
+    client: Client;
+    templates: Templates;
+    outputPath: string;
+    httpClient: HttpClient;
+    request?: string;
+}
+
+/**
  * Generate OpenAPI core files, this includes the basic boilerplate code to handle requests.
  * @param client Client object, containing, models, schemas and services
  * @param templates The loaded handlebar templates
@@ -13,7 +28,8 @@ import { Templates } from './registerHandlebarTemplates';
  * @param httpClient The selected httpClient (fetch, xhr or node)
  * @param request: Path to custom request file
  */
-export async function writeClientCore(client: Client, templates: Templates, outputPath: string, httpClient: HttpClient, request?: string): Promise<void> {
+export async function writeClientCore(options: IWriteClientCore): Promise<void> {
+    const { client, templates, outputPath, httpClient, request } = options;
     const context = {
         httpClient,
         server: client.server,

--- a/src/utils/writeClientIndex.spec.ts
+++ b/src/utils/writeClientIndex.spec.ts
@@ -30,7 +30,7 @@ describe('writeClientIndex', () => {
             },
         };
 
-        await writeClientIndex(client, templates, '/', true, true, true, true, true);
+        await writeClientIndex({ client, templates, outputPath: '/', useUnionTypes: true, exportSchemas: true, exportCore: true, exportModels: true, exportServices: true });
 
         expect(writeFile).toBeCalledWith('/index.ts', 'index');
     });

--- a/src/utils/writeClientIndex.ts
+++ b/src/utils/writeClientIndex.ts
@@ -7,6 +7,26 @@ import { sortModelsByName } from './sortModelsByName';
 import { sortServicesByName } from './sortServicesByName';
 
 /**
+ * @param templates The loaded handlebar templates
+ * @param outputPath Directory to write the generated files to
+ * @param useUnionTypes Use union types instead of enums
+ * @param exportCore: Generate core
+ * @param exportServices: Generate services
+ * @param exportModels: Generate models
+ * @param exportSchemas: Generate schemas
+ */
+interface IWriteClientIndex {
+    client: Client;
+    templates: Templates;
+    outputPath: string;
+    useUnionTypes: boolean;
+    exportCore: boolean;
+    exportServices: boolean;
+    exportModels: boolean;
+    exportSchemas: boolean;
+}
+
+/**
  * Generate the OpenAPI client index file using the Handlebar template and write it to disk.
  * The index file just contains all the exports you need to use the client as a standalone
  * library. But yuo can also import individual models and services directly.
@@ -19,16 +39,8 @@ import { sortServicesByName } from './sortServicesByName';
  * @param exportModels: Generate models
  * @param exportSchemas: Generate schemas
  */
-export async function writeClientIndex(
-    client: Client,
-    templates: Templates,
-    outputPath: string,
-    useUnionTypes: boolean,
-    exportCore: boolean,
-    exportServices: boolean,
-    exportModels: boolean,
-    exportSchemas: boolean
-): Promise<void> {
+export async function writeClientIndex(options: IWriteClientIndex): Promise<void> {
+    const { client, templates, outputPath, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas } = options;
     await writeFile(
         resolve(outputPath, 'index.ts'),
         templates.index({

--- a/src/utils/writeClientModels.spec.ts
+++ b/src/utils/writeClientModels.spec.ts
@@ -26,6 +26,7 @@ describe('writeClientModels', () => {
                 enum: [],
                 enums: [],
                 properties: [],
+                alias: '',
             },
         ];
 
@@ -45,7 +46,7 @@ describe('writeClientModels', () => {
             },
         };
 
-        await writeClientModels(models, templates, '/', HttpClient.FETCH, false);
+        await writeClientModels({ models, templates, outputPath: '/', httpClient: HttpClient.FETCH, useUnionTypes: false });
 
         expect(writeFile).toBeCalledWith('/MyModel.ts', 'model');
     });

--- a/src/utils/writeClientModels.ts
+++ b/src/utils/writeClientModels.ts
@@ -1,11 +1,26 @@
 import { mkdirSync } from 'fs';
-import { resolve, dirname } from 'path';
+import { dirname, resolve } from 'path';
 
 import type { Model } from '../client/interfaces/Model';
 import { HttpClient } from '../HttpClient';
 import { writeFile } from './fileSystem';
 import { format } from './format';
 import { Templates } from './registerHandlebarTemplates';
+
+/**
+ * @param models Array of Models to write
+ * @param templates The loaded handlebar templates
+ * @param outputPath Directory to write the generated files to
+ * @param httpClient The selected httpClient (fetch, xhr or node)
+ * @param useUnionTypes Use union types instead of enums
+ */
+interface IWriteClientModels {
+    models: Model[];
+    templates: Templates;
+    outputPath: string;
+    httpClient: HttpClient;
+    useUnionTypes: boolean;
+}
 
 /**
  * Generate Models using the Handlebar template and write to disk.
@@ -15,7 +30,8 @@ import { Templates } from './registerHandlebarTemplates';
  * @param httpClient The selected httpClient (fetch, xhr or node)
  * @param useUnionTypes Use union types instead of enums
  */
-export async function writeClientModels(models: Model[], templates: Templates, outputPath: string, httpClient: HttpClient, useUnionTypes: boolean): Promise<void> {
+export async function writeClientModels(options: IWriteClientModels): Promise<void> {
+    const { models, templates, outputPath, httpClient, useUnionTypes } = options;
     for (const model of models) {
         const dir = dirname(model.path);
         if (dir) {

--- a/src/utils/writeClientSchemas.spec.ts
+++ b/src/utils/writeClientSchemas.spec.ts
@@ -46,7 +46,7 @@ describe('writeClientSchemas', () => {
             },
         };
 
-        await writeClientSchemas(models, templates, '/', HttpClient.FETCH, false);
+        await writeClientSchemas({ models, templates, outputPath: '/', httpClient: HttpClient.FETCH, useUnionTypes: false });
 
         expect(writeFile).toBeCalledWith('/MyModelSchema.ts', 'schema');
     });

--- a/src/utils/writeClientSchemas.ts
+++ b/src/utils/writeClientSchemas.ts
@@ -8,6 +8,21 @@ import { format } from './format';
 import { Templates } from './registerHandlebarTemplates';
 
 /**
+ * @param models Array of Models to write
+ * @param templates The loaded handlebar templates
+ * @param outputPath Directory to write the generated files to
+ * @param httpClient The selected httpClient (fetch, xhr or node)
+ * @param useUnionTypes Use union types instead of enums
+ */
+interface IWriteClientSchemas {
+    models: Model[];
+    templates: Templates;
+    outputPath: string;
+    httpClient: HttpClient;
+    useUnionTypes: boolean;
+}
+
+/**
  * Generate Schemas using the Handlebar template and write to disk.
  * @param models Array of Models to write
  * @param templates The loaded handlebar templates
@@ -15,7 +30,8 @@ import { Templates } from './registerHandlebarTemplates';
  * @param httpClient The selected httpClient (fetch, xhr or node)
  * @param useUnionTypes Use union types instead of enums
  */
-export async function writeClientSchemas(models: Model[], templates: Templates, outputPath: string, httpClient: HttpClient, useUnionTypes: boolean): Promise<void> {
+export async function writeClientSchemas(options: IWriteClientSchemas): Promise<void> {
+    const { models, templates, outputPath, httpClient, useUnionTypes } = options;
     for (const model of models) {
         const dir = dirname(model.path);
         if (dir) {

--- a/src/utils/writeClientServices.spec.ts
+++ b/src/utils/writeClientServices.spec.ts
@@ -32,7 +32,7 @@ describe('writeClientServices', () => {
             },
         };
 
-        await writeClientServices(services, templates, '/', HttpClient.FETCH, false, false);
+        await writeClientServices({ services, templates, outputPath: '/', httpClient: HttpClient.FETCH, useOptions: false, useUnionTypes: false, useCustomRequest: false });
 
         expect(writeFile).toBeCalledWith('/MyService.ts', 'service');
     });

--- a/src/utils/writeClientServices.ts
+++ b/src/utils/writeClientServices.ts
@@ -9,6 +9,25 @@ import { Templates } from './registerHandlebarTemplates';
 const VERSION_TEMPLATE_STRING = 'OpenAPI.VERSION';
 
 /**
+ * @param services Array of Services to write
+ * @param templates The loaded handlebar templates
+ * @param outputPath Directory to write the generated files to
+ * @param httpClient The selected httpClient (fetch, xhr or node)
+ * @param useUnionTypes Use union types instead of enums
+ * @param useOptions Use options or arguments functions
+ * @param useCustomRequest Use custom request file.
+ */
+interface IWriteClientServices {
+    services: Service[];
+    templates: Templates;
+    outputPath: string;
+    httpClient: HttpClient;
+    useUnionTypes: boolean;
+    useOptions: boolean;
+    useCustomRequest: boolean;
+}
+
+/**
  * Generate Services using the Handlebar template and write to disk.
  * @param services Array of Services to write
  * @param templates The loaded handlebar templates
@@ -17,7 +36,8 @@ const VERSION_TEMPLATE_STRING = 'OpenAPI.VERSION';
  * @param useUnionTypes Use union types instead of enums
  * @param useOptions Use options or arguments functions
  */
-export async function writeClientServices(services: Service[], templates: Templates, outputPath: string, httpClient: HttpClient, useUnionTypes: boolean, useOptions: boolean): Promise<void> {
+export async function writeClientServices(options: IWriteClientServices): Promise<void> {
+    const { services, templates, outputPath, httpClient, useUnionTypes, useOptions, useCustomRequest } = options;
     for (const service of services) {
         const file = resolve(outputPath, `${service.name}.ts`);
         const useVersion = service.operations.some(operation => operation.path.includes(VERSION_TEMPLATE_STRING));
@@ -27,6 +47,7 @@ export async function writeClientServices(services: Service[], templates: Templa
             useUnionTypes,
             useVersion,
             useOptions,
+            useCustomRequest,
         });
         await writeFile(file, format(templateResult));
     }

--- a/test/custom/request.ts
+++ b/test/custom/request.ts
@@ -2,12 +2,9 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { ApiRequestOptions } from './ApiRequestOptions';
-import type { ApiResult } from './ApiResult';
-import { OpenAPI } from './OpenAPI';
 
-export async function request(options: ApiRequestOptions): Promise<ApiResult> {
-
-    const url = `${OpenAPI.BASE}${options.path}`;
+export async function request(options: ApiRequestOptions): Promise<Record<string, any>> {
+    const url = `${options.path}`;
 
     // Do your request...
 


### PR DESCRIPTION
You need to modify the template script for your custom request.
Provide the ability to specify the return data type from the model for the response. Return not the body, but the response of the request.
Move the parameters of the "writeClient*" functions to the interfaces. For ease of use and subsequent expansion.