### PR TITLE
#58 Fixed generation of relative import path and model relative path when generating on Windows OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1-rc.0] - 2023-10-12
+
+### Fixed
+- Fixed the conversion of lines into an array of lines inside the function calculateRelationPath (incoming parameters).
+- Fixed typification of generator options used in the function generate.
+- Fixed the use of the function of obtaining a relative path of the model.
+- Fixed the logic of the getType function to specify version 2.
+- Fixed the installation of the prefix for the interface (interfacePrefix).
+- Fixed the installation of the prefix for the enum (enumPrefix).
+- Fixed the installation of the prefix for the type (typePrefix).
+
+### Updated
+- Updated the unit test for the function getType.
+- Updated the class Parser to specify version 2.
+
+### Deleted
+- Deleted all unused imports and unused utiliities.
+
 ## [0.3.1-beta.3] - 2023-07-14
 
 ### Fixed

--- a/bin/index.js
+++ b/bin/index.js
@@ -8,6 +8,26 @@ const pkg = require('../package.json');
 
 const OpenAPI = require(path.resolve(__dirname, '../dist/index.js'));
 
+/**
+ * Checks if `value` is `null` or `undefined`.
+ *
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is nullish, else `false`.
+ * @example
+ *
+ * isNil(null)
+ * // => true
+ *
+ * isNil(void 0)
+ * // => true
+ *
+ * isNil(NaN)
+ * // => false
+ */
+function isNil(value) {
+    return value == null;
+}
+
 const params = program
     .name('openapi')
     .usage('[options]')
@@ -61,9 +81,9 @@ function prepareRootOptions(options) {
         exportSchemas: isValidJson(options.exportSchemas) ? JSON.parse(options.exportSchemas) : false,
         clean: isValidJson(options.clean) ? JSON.parse(options.clean) : false,
         request: options.request,
-        interfacePrefix: options.interfacePrefix ? options.interfacePrefix : 'I',
-        enumPrefix: options.enumPrefix ? options.enumPrefix : 'E',
-        typePrefix: options.typePrefix ? options.typePrefix : 'T',
+        interfacePrefix: !isNil(options.interfacePrefix) ? options.interfacePrefix : 'I',
+        enumPrefix: !isNil(options.enumPrefix) ? options.enumPrefix : 'E',
+        typePrefix: !isNil(options.typePrefix) ? options.typePrefix : 'T',
     };
 }
 
@@ -88,9 +108,9 @@ function prepareOptions(options, rootOptions) {
             exportSchemas: isValidJson(option.exportSchemas) ? JSON.parse(option.exportSchemas) : rootOptions ? rootOptions.exportSchemas : false,
             clean: isValidJson(option.clean) ? JSON.parse(option.clean) : rootOptions ? rootOptions.clean : false,
             request: option.request ? option.request : rootOptions ? rootOptions.request : '',
-            interfacePrefix: option.interfacePrefix ? option.interfacePrefix : rootOptions ? rootOptions.interfacePrefix : 'I',
-            enumPrefix: option.enumPrefix ? option.enumPrefix : rootOptions ? rootOptions.enumPrefix : 'E',
-            typePrefix: option.typePrefix ? option.typePrefix : rootOptions ? rootOptions.typePrefix : 'T',
+            interfacePrefix: !isNil(option.interfacePrefix) ? option.interfacePrefix : rootOptions ? rootOptions.interfacePrefix : 'I',
+            enumPrefix: !isNil(option.enumPrefix) ? option.enumPrefix : rootOptions ? rootOptions.enumPrefix : 'E',
+            typePrefix: !isNil(option.typePrefix) ? option.typePrefix : rootOptions ? rootOptions.typePrefix : 'T',
         };
     });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-openapi-codegen",
-    "version": "0.3.1-beta.3",
+    "version": "0.3.1-rc.0",
     "description": "Library that generates Typescript clients based on the OpenAPI specification. It bases on openapi-typescript-codegen",
     "author": "Alexey Zverev",
     "homepage": "https://github.com/ozonophore/openapi-codegen.git",

--- a/src/core/path.ts
+++ b/src/core/path.ts
@@ -19,3 +19,7 @@ export function relative(from: string, to: string): string {
 export function resolve(...pathSegments: string[]): string {
     return path.resolve(...pathSegments).replace(SEARCH_REGEXP, '/');
 }
+
+export function normalize(p: string): string {
+    return path.normalize(p).replace(SEARCH_REGEXP, '/');
+}

--- a/src/openApi/v2/Parser.ts
+++ b/src/openApi/v2/Parser.ts
@@ -13,10 +13,14 @@ import { getType } from './parser/getType';
 import { parse } from './parserV2';
 
 export class Parser {
-    public context: Context;
+    public _context: Context;
 
     constructor(context: Context) {
-        this.context = context;
+        this._context = context;
+    }
+
+    get context(): Context {
+        return this._context;
     }
 
     public getTypeNameByRef(value: string, ref?: string): string {

--- a/src/openApi/v2/parser/getModel.ts
+++ b/src/openApi/v2/parser/getModel.ts
@@ -6,7 +6,6 @@ import { extendEnum } from './extendEnum';
 import { getComment } from './getComment';
 import { getEnum } from './getEnum';
 import { getEnumFromDescription } from './getEnumFromDescription';
-import { getType } from './getType';
 
 export function getModel(this: Parser, config: ModelConfig): Model {
     const { openApi, definition, isDefinition = false, name = '', path = '', parentRef } = config;
@@ -46,7 +45,7 @@ export function getModel(this: Parser, config: ModelConfig): Model {
     };
 
     if (definition.$ref) {
-        const definitionRef = getType(definition.$ref);
+        const definitionRef = this.getType(definition.$ref, parentRef);
         model.export = 'reference';
         model.type = definitionRef.type;
         model.base = definitionRef.base;
@@ -80,7 +79,7 @@ export function getModel(this: Parser, config: ModelConfig): Model {
 
     if (definition.type === 'array' && definition.items) {
         if (definition.items.$ref) {
-            const arrayItems = getType(definition.items.$ref);
+            const arrayItems = this.getType(definition.items.$ref, parentRef);
             model.export = 'array';
             model.type = arrayItems.type;
             model.base = arrayItems.base;
@@ -101,7 +100,7 @@ export function getModel(this: Parser, config: ModelConfig): Model {
 
     if (definition.type === 'object' && typeof definition.additionalProperties === 'object') {
         if (definition.additionalProperties.$ref) {
-            const additionalProperties = getType(definition.additionalProperties.$ref);
+            const additionalProperties = this.getType(definition.additionalProperties.$ref, parentRef);
             model.export = 'dictionary';
             model.type = additionalProperties.type;
             model.base = additionalProperties.base;
@@ -150,7 +149,7 @@ export function getModel(this: Parser, config: ModelConfig): Model {
 
     // If the schema has a type than it can be a basic or generic type.
     if (definition.type) {
-        const definitionType = getType(definition.type);
+        const definitionType = this.getType(definition.type, parentRef);
         model.export = 'generic';
         model.type = definitionType.type;
         model.base = definitionType.base;

--- a/src/openApi/v2/parser/getModelProperties.ts
+++ b/src/openApi/v2/parser/getModelProperties.ts
@@ -5,7 +5,6 @@ import type { OpenApiSchema } from '../interfaces/OpenApiSchema';
 import { Parser } from '../Parser';
 import { escapeName } from './escapeName';
 import { getComment } from './getComment';
-import { getType } from './getType';
 
 export function getModelProperties(this: Parser, openApi: OpenApi, definition: OpenApiSchema, parentRef: string): Model[] {
     const models: Model[] = [];
@@ -14,7 +13,7 @@ export function getModelProperties(this: Parser, openApi: OpenApi, definition: O
             const property = definition.properties[propertyName];
             const propertyRequired = definition.required?.includes(propertyName) || property.default !== undefined;
             if (property.$ref) {
-                const model = getType(property.$ref);
+                const model = this.getType(property.$ref, parentRef);
                 models.push({
                     name: escapeName(propertyName),
                     alias: '',

--- a/src/openApi/v2/parser/getModels.ts
+++ b/src/openApi/v2/parser/getModels.ts
@@ -2,7 +2,6 @@ import type { Model } from '../../../client/interfaces/Model';
 import { join, relative } from '../../../core/path';
 import { getRefFromSchema } from '../../../utils/getRefFromSchema';
 import { getRelativeModelImportPath } from '../../../utils/getRelativeModelImportPath';
-import { getRelativeModelPath } from '../../../utils/getRelativeModelPath';
 import { sortModelsByName } from '../../../utils/sortModelsByName';
 import { unique } from '../../../utils/unique';
 import type { OpenApi } from '../interfaces/OpenApi';
@@ -15,13 +14,12 @@ export function getModels(this: Parser, openApi: OpenApi): Model[] {
         for (const modelRef of listOfModelsRef) {
             const definition: any = this.context.get(modelRef);
             const definitionType = this.getType(modelRef, '');
-            const modelPath = getRelativeModelPath(this.context.output?.outputModels, definitionType.path);
             const model = this.getModel({
                 openApi: openApi,
                 definition: definition,
                 isDefinition: true,
                 name: definitionType.base,
-                path: modelPath,
+                path: definitionType.path,
                 parentRef: modelRef,
             });
             models.push(model);

--- a/src/openApi/v2/parser/getOperationParameter.ts
+++ b/src/openApi/v2/parser/getOperationParameter.ts
@@ -2,15 +2,13 @@ import type { OperationParameter } from '../../../client/interfaces/OperationPar
 import { getPattern } from '../../../utils/getPattern';
 import type { OpenApi } from '../interfaces/OpenApi';
 import type { OpenApiParameter } from '../interfaces/OpenApiParameter';
+import { Parser } from '../Parser';
 import { extendEnum } from './extendEnum';
 import { getComment } from './getComment';
 import { getEnum } from './getEnum';
 import { getEnumFromDescription } from './getEnumFromDescription';
-import { getModel } from './getModel';
 import { getOperationParameterDefault } from './getOperationParameterDefault';
 import { getOperationParameterName } from './getOperationParameterName';
-import { getType } from './getType';
-import { Parser } from '../Parser';
 
 export function getOperationParameter(this: Parser, openApi: OpenApi, parameter: OpenApiParameter): OperationParameter {
     const operationParameter: OperationParameter = {
@@ -49,7 +47,7 @@ export function getOperationParameter(this: Parser, openApi: OpenApi, parameter:
     };
 
     if (parameter.$ref) {
-        const definitionRef = getType(parameter.$ref);
+        const definitionRef = this.getType(parameter.$ref, '');
         operationParameter.export = 'reference';
         operationParameter.type = definitionRef.type;
         operationParameter.base = definitionRef.base;
@@ -85,8 +83,8 @@ export function getOperationParameter(this: Parser, openApi: OpenApi, parameter:
         }
     }
 
-    if (parameter.type === 'array' && parameter.items) {
-        const items = getType(parameter.items.type);
+    if (parameter.type === 'array' && parameter?.items?.type) {
+        const items = this.getType(parameter.items.type, '');
         operationParameter.export = 'array';
         operationParameter.type = items.type;
         operationParameter.base = items.base;
@@ -96,8 +94,8 @@ export function getOperationParameter(this: Parser, openApi: OpenApi, parameter:
         return operationParameter;
     }
 
-    if (parameter.type === 'object' && parameter.items) {
-        const items = getType(parameter.items.type);
+    if (parameter.type === 'object' && parameter?.items?.type) {
+        const items = this.getType(parameter.items.type, '');
         operationParameter.export = 'dictionary';
         operationParameter.type = items.type;
         operationParameter.base = items.base;
@@ -109,7 +107,7 @@ export function getOperationParameter(this: Parser, openApi: OpenApi, parameter:
 
     if (parameter.schema) {
         if (parameter.schema.$ref) {
-            const model = getType(parameter.schema.$ref);
+            const model = this.getType(parameter.schema.$ref, '');
             operationParameter.export = 'reference';
             operationParameter.type = model.type;
             operationParameter.base = model.base;
@@ -135,7 +133,7 @@ export function getOperationParameter(this: Parser, openApi: OpenApi, parameter:
 
     // If the parameter has a type than it can be a basic or generic type.
     if (parameter.type) {
-        const definitionType = getType(parameter.type);
+        const definitionType = this.getType(parameter.type, '');
         operationParameter.export = 'generic';
         operationParameter.type = definitionType.type;
         operationParameter.base = definitionType.base;

--- a/src/openApi/v2/parser/getOperationResponse.ts
+++ b/src/openApi/v2/parser/getOperationResponse.ts
@@ -4,9 +4,8 @@ import type { OpenApi } from '../interfaces/OpenApi';
 import type { OpenApiResponse } from '../interfaces/OpenApiResponse';
 import { Parser } from '../Parser';
 import { getComment } from './getComment';
-import { getType } from './getType';
 
-export function getOperationResponse(this: Parser, openApi: OpenApi, response: OpenApiResponse, responseCode: number): OperationResponse {
+export function getOperationResponse(this: Parser, openApi: OpenApi, response: OpenApiResponse, responseCode: number, parentRef: string): OperationResponse {
     const operationResponse: OperationResponse = {
         in: 'response',
         name: '',
@@ -35,7 +34,7 @@ export function getOperationResponse(this: Parser, openApi: OpenApi, response: O
     // then we need to parse the schema!
     if (response.schema) {
         if (response.schema.$ref) {
-            const model = getType(response.schema.$ref);
+            const model = this.getType(response.schema.$ref, parentRef);
             operationResponse.export = 'reference';
             operationResponse.type = model.type;
             operationResponse.base = model.base;
@@ -43,7 +42,7 @@ export function getOperationResponse(this: Parser, openApi: OpenApi, response: O
             operationResponse.imports.push(...model.imports);
             return operationResponse;
         } else {
-            const model = this.getModel({ openApi: openApi, definition: response.schema, parentRef: '' });
+            const model = this.getModel({ openApi: openApi, definition: response.schema, parentRef: parentRef });
             operationResponse.export = model.export;
             operationResponse.type = model.type;
             operationResponse.base = model.base;

--- a/src/openApi/v2/parser/getOperationResponses.ts
+++ b/src/openApi/v2/parser/getOperationResponses.ts
@@ -17,7 +17,7 @@ export function getOperationResponses(this: Parser, openApi: OpenApi, responses:
             const responseCode = getOperationResponseCode(code);
 
             if (responseCode) {
-                const operationResponse = this.getOperationResponse(openApi, response, responseCode);
+                const operationResponse = this.getOperationResponse(openApi, response, responseCode, '');
                 operationResponses.push(operationResponse);
             }
         }

--- a/src/openApi/v2/parser/getType.ts
+++ b/src/openApi/v2/parser/getType.ts
@@ -1,11 +1,11 @@
 import type { Type } from '../../../client/interfaces/Type';
 import { replaceString } from '../../../core/replaceString';
+import { encode } from '../../../utils/encode';
+import { getAbsolutePath } from '../../../utils/getAbsolutePath';
 import { getMappedType, hasMappedType } from '../../../utils/getMappedType';
+import { getRelativeModelPath } from '../../../utils/getRelativeModelPath';
 import { stripNamespace } from '../../../utils/stripNamespace';
-
-function encode(value: string): string {
-    return value.replace(/^[^a-zA-Z_$]+/g, '').replace(/[^\w$]+/g, '_');
-}
+import { Parser } from '../Parser';
 
 function getTypeName(value: string): string {
     const index = value.lastIndexOf('/');
@@ -15,24 +15,14 @@ function getTypeName(value: string): string {
     return encode(value.substring(index, value.length));
 }
 
-function getPath(value?: string): string {
-    if (!value) {
-        return '';
-    }
-    const index = value.lastIndexOf('/');
-    if (index === -1) {
-        return '';
-    }
-    return value.substring(0, index + 1);
-}
-
 /**
  * Parse any string value into a type object.
  * @param value String value like "integer" or "Link[Model]".
- * @param template Optional template class from parent (needed to process generics)
+ * @param parentRef Reference to a parent model
  */
-export function getType(value?: string, template?: string): Type {
+export function getType(this: Parser, value: string, parentRef: string): Type {
     const normalizedValue = replaceString(value);
+
     const result: Type = {
         type: 'any',
         base: 'any',
@@ -42,52 +32,20 @@ export function getType(value?: string, template?: string): Type {
     };
 
     const valueClean = stripNamespace(normalizedValue || '');
-    result.path = getPath(valueClean);
-    if (/\[.*\]$/g.test(valueClean)) {
-        const matches = valueClean.match(/(.*?)\[(.*)\]$/);
-        if (matches?.length) {
-            const match1 = getType(matches[1]);
-            result.path = match1.path;
-            const match2 = getType(matches[2]);
-
-            if (match1.type === 'any[]') {
-                result.type = `${match2.type}[]`;
-                result.base = match2.type;
-                match1.imports = [];
-            } else if (match2.type) {
-                result.type = `${match1.type}<${match2.type}>`;
-                result.base = match1.type;
-                result.template = match2.type;
-            } else {
-                result.type = match1.type;
-                result.base = match1.type;
-                result.template = match1.type;
-            }
-
-            result.imports.push(...match1.imports);
-            result.imports.push(...match2.imports);
-        }
-    } else if (hasMappedType(valueClean)) {
+    const valuePath = getRelativeModelPath(this.context.output?.outputModels, valueClean);
+    if (hasMappedType(valueClean)) {
         const mapped = getMappedType(valueClean);
-        result.path = valueClean;
+        result.path = valuePath;
         if (mapped) {
             result.type = mapped;
             result.base = mapped;
         }
     } else if (valueClean) {
-        const type = getTypeName(valueClean);
-        result.path = valueClean;
+        const type = this.getTypeNameByRef(getTypeName(valueClean), getAbsolutePath(value, parentRef));
+        result.path = valuePath;
         result.type = type;
         result.base = type;
         result.imports.push({ name: type, alias: '', path: valueClean });
-    }
-
-    // If the property that we found matched the parent template class
-    // Then ignore this whole property and return it as a "T" template property.
-    if (result.type === template) {
-        result.type = 'T'; // Template;
-        result.base = 'T'; // Template;
-        result.imports = [];
     }
 
     return result;

--- a/src/openApi/v3/Parser.ts
+++ b/src/openApi/v3/Parser.ts
@@ -1,5 +1,4 @@
 import { Context } from '../../core/Context';
-import { getRefFromSchema } from '../../utils/getRefFromSchema';
 import { getModel } from '../v3/parser/getModel';
 import { getModelComposition } from './parser/getModelComposition';
 import { getModelProperties } from './parser/getModelProperties';

--- a/src/openApi/v3/parser/getModelProperties.ts
+++ b/src/openApi/v3/parser/getModelProperties.ts
@@ -1,11 +1,11 @@
 import type { Model } from '../../../client/interfaces/Model';
+import { getClassName } from '../../../utils/getClassName';
 import { getPattern } from '../../../utils/getPattern';
 import type { OpenApi } from '../interfaces/OpenApi';
 import type { OpenApiSchema } from '../interfaces/OpenApiSchema';
 import { Parser } from '../Parser';
 import { escapeName } from './escapeName';
 import { getComment } from './getComment';
-import { getClassName } from '../../../utils/getClassName';
 
 export function getModelProperties(this: Parser, openApi: OpenApi, definition: OpenApiSchema, parentRef: string): Model[] {
     const models: Model[] = [];

--- a/src/openApi/v3/parser/getModels.ts
+++ b/src/openApi/v3/parser/getModels.ts
@@ -2,7 +2,6 @@ import type { Model } from '../../../client/interfaces/Model';
 import { join, relative } from '../../../core/path';
 import { getRefFromSchema } from '../../../utils/getRefFromSchema';
 import { getRelativeModelImportPath } from '../../../utils/getRelativeModelImportPath';
-import { getRelativeModelPath } from '../../../utils/getRelativeModelPath';
 import { sortModelsByName } from '../../../utils/sortModelsByName';
 import { unique } from '../../../utils/unique';
 import type { OpenApi } from '../interfaces/OpenApi';
@@ -15,13 +14,12 @@ export function getModels(this: Parser, openApi: OpenApi): Model[] {
         for (const modelRef of listOfModelsRef) {
             const definition: any = this.context.get(modelRef);
             const definitionType = this.getType(modelRef, '');
-            const modelPath = getRelativeModelPath(this.context.output?.outputModels, definitionType.path);
             const model = this.getModel({
                 openApi: openApi,
                 definition: definition,
                 isDefinition: true,
                 name: definitionType.base,
-                path: modelPath,
+                path: definitionType.path,
                 parentRef: modelRef,
             });
             models.push(model);

--- a/src/openApi/v3/parser/getOperationParameters.ts
+++ b/src/openApi/v3/parser/getOperationParameters.ts
@@ -1,11 +1,8 @@
 import type { OperationParameters } from '../../../client/interfaces/OperationParameters';
-import { Context } from '../../../core/Context';
+import { sortByRequired } from '../../../utils/sortByRequired';
 import type { OpenApi } from '../interfaces/OpenApi';
 import type { OpenApiParameter } from '../interfaces/OpenApiParameter';
 import { Parser } from '../Parser';
-import { getOperationParameter } from './getOperationParameter';
-import { GetTypeName } from './getType';
-import { sortByRequired } from '../../../utils/sortByRequired';
 
 export function getOperationParameters(this: Parser, openApi: OpenApi, parameters: OpenApiParameter[]): OperationParameters {
     const operationParameters: OperationParameters = {

--- a/src/openApi/v3/parser/getOperationResponse.ts
+++ b/src/openApi/v3/parser/getOperationResponse.ts
@@ -5,8 +5,6 @@ import type { OpenApiResponse } from '../interfaces/OpenApiResponse';
 import { Parser } from '../Parser';
 import { getComment } from './getComment';
 import { getContent } from './getContent';
-import { getModel } from './getModel';
-import { getType } from './getType';
 
 export function getOperationResponse(this: Parser, openApi: OpenApi, response: OpenApiResponse, responseCode: number, parentRef: string): OperationResponse {
     const operationResponse: OperationResponse = {

--- a/src/openApi/v3/parser/getType.spec.ts
+++ b/src/openApi/v3/parser/getType.spec.ts
@@ -2,7 +2,6 @@ import RefParser from 'json-schema-ref-parser';
 
 import { Context } from '../../../core/Context';
 import { Parser } from '../Parser';
-import { getType } from './getType';
 
 describe('getType', () => {
     it('should convert int', async () => {

--- a/src/openApi/v3/parser/getType.ts
+++ b/src/openApi/v3/parser/getType.ts
@@ -3,6 +3,7 @@ import { replaceString } from '../../../core/replaceString';
 import { encode } from '../../../utils/encode';
 import { getAbsolutePath } from '../../../utils/getAbsolutePath';
 import { getMappedType, hasMappedType } from '../../../utils/getMappedType';
+import { getRelativeModelPath } from '../../../utils/getRelativeModelPath';
 import { stripNamespace } from '../../../utils/stripNamespace';
 import { Parser } from '../Parser';
 
@@ -13,13 +14,6 @@ function getTypeName(value: string): string {
     }
     return encode(value.substring(index, value.length));
 }
-
-/**
- * Returns type name that depends on ref
- * @param type String - original type name
- * @param ref String - optional reference to object
- */
-export type GetTypeName = (type: string, ref?: string) => string;
 
 /**
  * Parse any string value into a type object.
@@ -38,16 +32,17 @@ export function getType(this: Parser, value: string, parentRef: string): Type {
     };
 
     const valueClean = stripNamespace(normalizedValue || '');
+    const valuePath = getRelativeModelPath(this.context.output?.outputModels, valueClean);
     if (hasMappedType(valueClean)) {
         const mapped = getMappedType(valueClean);
-        result.path = valueClean;
+        result.path = valuePath;
         if (mapped) {
             result.type = mapped;
             result.base = mapped;
         }
     } else if (valueClean) {
         const type = this.getTypeNameByRef(getTypeName(valueClean), getAbsolutePath(value, parentRef));
-        result.path = valueClean;
+        result.path = valuePath;
         result.type = type;
         result.base = type;
         result.imports.push({ name: type, alias: '', path: valueClean });

--- a/src/utils/getRelativeModelImportPath.ts
+++ b/src/utils/getRelativeModelImportPath.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { resolve } from '../core/path';
+import { normalize, resolve } from '../core/path';
 import { replaceString } from '../core/replaceString';
 import { getRelativeModelPath } from './getRelativeModelPath';
 import { isPathWithRoot } from './isPathWithRoot';
@@ -44,18 +44,22 @@ export function getRelativeModelImportPath(rootPath: string | undefined, relativ
  * @returns Current relative model import path.
  */
 function calculateRelativePath(firstPath: string, secondPath: string): string {
-    const firstPathArr = firstPath.split('/');
-    const secondPathArr = secondPath.split('/');
+    try {
+        const firstPathArr = normalize(firstPath).split('/');
+        const secondPathArr = normalize(secondPath).split('/');
 
-    let i = 0;
-    while (i < firstPathArr.length && i < secondPathArr.length && firstPathArr[i] === secondPathArr[i]) {
-        i++;
+        let i = 0;
+        while (i < firstPathArr.length && i < secondPathArr.length && firstPathArr[i] === secondPathArr[i]) {
+            i++;
+        }
+
+        const backtracking = '../'.repeat(firstPathArr.length - i - 1);
+        const forwardPath = secondPathArr.slice(i).join('/');
+        let relativePath = backtracking + forwardPath;
+        const normalizedValue = replaceString(relativePath);
+        relativePath = stripNamespace(normalizedValue || '');
+        return relativePath;
+    } catch (error) {
+        throw error;
     }
-
-    const backtracking = '../'.repeat(firstPathArr.length - i - 1);
-    const forwardPath = secondPathArr.slice(i).join('/');
-    let relativePath = backtracking + forwardPath;
-    const normalizedValue = replaceString(relativePath);
-    relativePath = stripNamespace(normalizedValue || '');
-    return relativePath;
 }

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -339,21 +339,21 @@ exports[`v2 should generate: ./test/generated/v2/index.ts 1`] = `
 export { ApiError } from '././core/ApiError';
 export { OpenAPI } from '././core/OpenAPI';
 
-export type { DictionaryWithReference } from '././models/DictionaryWithReference';
-export type { ModelThatExtends } from '././models/ModelThatExtends';
-export type { ModelThatExtendsExtends } from '././models/ModelThatExtendsExtends';
-export type { ModelWithArray } from '././models/ModelWithArray';
-export type { ModelWithDictionary } from '././models/ModelWithDictionary';
-export { ModelWithEnumInteger } from '././models/ModelWithEnumInteger';
-export type { ModelWithString } from '././models/ModelWithString';
+export type { IDictionaryWithReference } from '././models/DictionaryWithReference';
+export type { IModelWithArray } from '././models/ModelWithArray';
+export type { IModelWithDictionary } from '././models/ModelWithDictionary';
+export { IModelWithEnumInteger } from '././models/ModelWithEnumInteger';
+export type { IModelWithString } from '././models/ModelWithString';
+export type { TModelThatExtends } from '././models/ModelThatExtends';
+export type { TModelThatExtendsExtends } from '././models/ModelThatExtendsExtends';
 
-export { DictionaryWithReferenceSchema } from '././schemas/DictionaryWithReferenceSchema';
-export { ModelThatExtendsSchema } from '././schemas/ModelThatExtendsSchema';
-export { ModelThatExtendsExtendsSchema } from '././schemas/ModelThatExtendsExtendsSchema';
-export { ModelWithArraySchema } from '././schemas/ModelWithArraySchema';
-export { ModelWithDictionarySchema } from '././schemas/ModelWithDictionarySchema';
-export { ModelWithEnumIntegerSchema } from '././schemas/ModelWithEnumIntegerSchema';
-export { ModelWithStringSchema } from '././schemas/ModelWithStringSchema';
+export { IDictionaryWithReferenceSchema } from '././schemas/DictionaryWithReferenceSchema';
+export { IModelWithArraySchema } from '././schemas/ModelWithArraySchema';
+export { IModelWithDictionarySchema } from '././schemas/ModelWithDictionarySchema';
+export { IModelWithEnumIntegerSchema } from '././schemas/ModelWithEnumIntegerSchema';
+export { IModelWithStringSchema } from '././schemas/ModelWithStringSchema';
+export { TModelThatExtendsSchema } from '././schemas/ModelThatExtendsSchema';
+export { TModelThatExtendsExtendsSchema } from '././schemas/ModelThatExtendsExtendsSchema';
 
 export { Service } from '././services/Service';
 export { SimpleService } from '././services/SimpleService';
@@ -374,12 +374,12 @@ exports[`v2 should generate: ./test/generated/v2/models/DictionaryWithReference.
 /* tslint:disable */
 /* eslint-disable */
 
-import type { ModelWithString } from './ModelWithString';
+import type { IModelWithString } from './ModelWithString';
 
 /**
  * This is a string reference
  */
-export type DictionaryWithReference = Record<string, ModelWithString>;"
+export type IDictionaryWithReference = Record<string, IModelWithString>;"
 `;
 
 exports[`v2 should generate: ./test/generated/v2/models/ModelThatExtends.ts 1`] = `
@@ -387,14 +387,14 @@ exports[`v2 should generate: ./test/generated/v2/models/ModelThatExtends.ts 1`] 
 /* tslint:disable */
 /* eslint-disable */
 
-import type { ModelWithString } from './ModelWithString';
+import type { IModelWithString } from './ModelWithString';
 
 /**
  * This is a model that extends another model
  */
-export type ModelThatExtends = (ModelWithString & {
+export type TModelThatExtends = (IModelWithString & {
     propExtendsA?: string,
-    propExtendsB?: ModelWithString,
+    propExtendsB?: IModelWithString,
 });
 "
 `;
@@ -404,15 +404,15 @@ exports[`v2 should generate: ./test/generated/v2/models/ModelThatExtendsExtends.
 /* tslint:disable */
 /* eslint-disable */
 
-import type { ModelThatExtends } from './ModelThatExtends';
-import type { ModelWithString } from './ModelWithString';
+import type { TModelThatExtends } from './ModelThatExtends';
+import type { IModelWithString } from './ModelWithString';
 
 /**
  * This is a model that extends another model
  */
-export type ModelThatExtendsExtends = (ModelWithString & ModelThatExtends & {
+export type TModelThatExtendsExtends = (IModelWithString & TModelThatExtends & {
     propExtendsC?: string,
-    propExtendsD?: ModelWithString,
+    propExtendsD?: IModelWithString,
 });
 "
 `;
@@ -422,13 +422,13 @@ exports[`v2 should generate: ./test/generated/v2/models/ModelWithArray.ts 1`] = 
 /* tslint:disable */
 /* eslint-disable */
 
-import type { ModelWithString } from './ModelWithString';
+import type { IModelWithString } from './ModelWithString';
 
 /**
  * This is a model with one property containing an array
  */
-export interface ModelWithArray {
-    prop?: Array<ModelWithString>;
+export interface IModelWithArray {
+    prop?: Array<IModelWithString>;
     propWithFile?: Array<Blob>;
     propWithNumber?: Array<number>;
 }
@@ -443,7 +443,7 @@ exports[`v2 should generate: ./test/generated/v2/models/ModelWithDictionary.ts 1
 /**
  * This is a model with one property containing a dictionary
  */
-export interface ModelWithDictionary {
+export interface IModelWithDictionary {
     prop?: Record<string, string>;
 }
 "
@@ -457,14 +457,14 @@ exports[`v2 should generate: ./test/generated/v2/models/ModelWithEnumInteger.ts 
 /**
  * This is a model with one number property
  */
-export interface ModelWithEnumInteger {
+export interface IModelWithEnumInteger {
     /**
      * VALUE_1=1,VALUE_2=2,VALUE_3=3
      */
-    prop?: ModelWithEnumInteger.prop;
+    prop?: IModelWithEnumInteger.prop;
 }
 
-export namespace ModelWithEnumInteger {
+export namespace IModelWithEnumInteger {
 
     /**
      * VALUE_1=1,VALUE_2=2,VALUE_3=3
@@ -488,7 +488,7 @@ exports[`v2 should generate: ./test/generated/v2/models/ModelWithString.ts 1`] =
 /**
  * This is a model with one string property
  */
-export interface ModelWithString {
+export interface IModelWithString {
     /**
      * This is a simple string property
      */
@@ -501,10 +501,10 @@ exports[`v2 should generate: ./test/generated/v2/schemas/DictionaryWithReference
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export const DictionaryWithReferenceSchema = {
+export const IDictionaryWithReferenceSchema = {
     type: 'dictionary',
     contains: {
-        type: 'ModelWithString',
+        type: 'IModelWithString',
     },
 };"
 `;
@@ -513,19 +513,19 @@ exports[`v2 should generate: ./test/generated/v2/schemas/ModelThatExtendsExtends
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export const ModelThatExtendsExtendsSchema = {
+export const TModelThatExtendsExtendsSchema = {
     type: 'all-of',
     contains: [{
-        type: 'ModelWithString',
+        type: 'IModelWithString',
     }, {
-        type: 'ModelThatExtends',
+        type: 'TModelThatExtends',
     }, {
         properties: {
             propExtendsC: {
                 type: 'string',
             },
             propExtendsD: {
-                type: 'ModelWithString',
+                type: 'IModelWithString',
             },
         },
     }],
@@ -536,17 +536,17 @@ exports[`v2 should generate: ./test/generated/v2/schemas/ModelThatExtendsSchema.
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export const ModelThatExtendsSchema = {
+export const TModelThatExtendsSchema = {
     type: 'all-of',
     contains: [{
-        type: 'ModelWithString',
+        type: 'IModelWithString',
     }, {
         properties: {
             propExtendsA: {
                 type: 'string',
             },
             propExtendsB: {
-                type: 'ModelWithString',
+                type: 'IModelWithString',
             },
         },
     }],
@@ -557,12 +557,12 @@ exports[`v2 should generate: ./test/generated/v2/schemas/ModelWithArraySchema.ts
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export const ModelWithArraySchema = {
+export const IModelWithArraySchema = {
     properties: {
         prop: {
             type: 'array',
             contains: {
-                type: 'ModelWithString',
+                type: 'IModelWithString',
             },
         },
         propWithFile: {
@@ -585,7 +585,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/ModelWithDictionarySche
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export const ModelWithDictionarySchema = {
+export const IModelWithDictionarySchema = {
     properties: {
         prop: {
             type: 'dictionary',
@@ -601,7 +601,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/ModelWithEnumIntegerSch
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export const ModelWithEnumIntegerSchema = {
+export const IModelWithEnumIntegerSchema = {
     properties: {
         prop: {
             type: 'Enum',
@@ -614,7 +614,7 @@ exports[`v2 should generate: ./test/generated/v2/schemas/ModelWithStringSchema.t
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export const ModelWithStringSchema = {
+export const IModelWithStringSchema = {
     properties: {
         prop: {
             type: 'string',
@@ -696,7 +696,7 @@ exports[`v2 should generate: ./test/generated/v2/services/ComplexService.ts 1`] 
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { ModelWithString } from './../models/ModelWithString';
+import type { IModelWithString } from './../models/ModelWithString';
 import { request as __request } from './../core/request';
 import type { ApiRequestOptions } from './../core/ApiRequestOptions';
 import { OpenAPI } from './../core/OpenAPI';
@@ -709,7 +709,7 @@ const complexTypes = (
             },
         },
     },
-    parameterReference: ModelWithString,
+    parameterReference: IModelWithString,
 ): ApiRequestOptions => ({
     method: 'GET',
     path: \`/api/v\${OpenAPI.VERSION}/complex\`,
@@ -733,7 +733,7 @@ export type TComplexServiceOptions = {
                 },
             },
         },
-        parameterReference: ModelWithString,
+        parameterReference: IModelWithString,
     ) => ApiRequestOptions;
 }
 
@@ -746,7 +746,7 @@ export class ComplexService {
     /**
      * @param parameterObject Parameter containing object
      * @param parameterReference Parameter containing reference
-     * @returns ModelWithString Successful response
+     * @returns IModelWithString Successful response
      * @throws ApiError
      */
     public static complexTypes(
@@ -757,9 +757,9 @@ export class ComplexService {
                 },
             },
         },
-        parameterReference: ModelWithString,
-    ): Promise<Array<ModelWithString>> {
-        return __request<Array<ModelWithString>>(ComplexServiceOptions.complexTypes(
+        parameterReference: IModelWithString,
+    ): Promise<Array<IModelWithString>> {
+        return __request<Array<IModelWithString>>(ComplexServiceOptions.complexTypes(
             parameterObject,
             parameterReference,
         ));
@@ -771,7 +771,7 @@ exports[`v2 should generate: ./test/generated/v2/services/DefaultsService.ts 1`]
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { ModelWithString } from './../models/ModelWithString';
+import type { IModelWithString } from './../models/ModelWithString';
 import { request as __request } from './../core/request';
 import type { ApiRequestOptions } from './../core/ApiRequestOptions';
 import { OpenAPI } from './../core/OpenAPI';
@@ -781,7 +781,7 @@ const callWithDefaultParameters = (
     parameterNumber: number = 123,
     parameterBoolean: boolean = true,
     parameterEnum: 'Success' | 'Warning' | 'Error' = 'Success',
-    parameterModel: ModelWithString = {
+    parameterModel: IModelWithString = {
         \\"prop\\": \\"Hello World!\\"
     },
 ): ApiRequestOptions => ({
@@ -801,7 +801,7 @@ const callWithDefaultOptionalParameters = (
     parameterNumber: number = 123,
     parameterBoolean: boolean = true,
     parameterEnum: 'Success' | 'Warning' | 'Error' = 'Success',
-    parameterModel: ModelWithString = {
+    parameterModel: IModelWithString = {
         \\"prop\\": \\"Hello World!\\"
     },
 ): ApiRequestOptions => ({
@@ -843,14 +843,14 @@ export type TDefaultsServiceOptions = {
         parameterNumber: number,
         parameterBoolean: boolean,
         parameterEnum: 'Success' | 'Warning' | 'Error',
-        parameterModel: ModelWithString,
+        parameterModel: IModelWithString,
     ) => ApiRequestOptions;
     callWithDefaultOptionalParameters: (
         parameterString: string,
         parameterNumber: number,
         parameterBoolean: boolean,
         parameterEnum: 'Success' | 'Warning' | 'Error',
-        parameterModel: ModelWithString,
+        parameterModel: IModelWithString,
     ) => ApiRequestOptions;
     callToTestOrderOfParams: (
         parameterStringWithNoDefault: string,
@@ -883,7 +883,7 @@ export class DefaultsService {
         parameterNumber: number = 123,
         parameterBoolean: boolean = true,
         parameterEnum: 'Success' | 'Warning' | 'Error' = 'Success',
-        parameterModel: ModelWithString = {
+        parameterModel: IModelWithString = {
             \\"prop\\": \\"Hello World!\\"
         },
     ): Promise<void> {
@@ -908,7 +908,7 @@ export class DefaultsService {
         parameterNumber: number = 123,
         parameterBoolean: boolean = true,
         parameterEnum: 'Success' | 'Warning' | 'Error' = 'Success',
-        parameterModel: ModelWithString = {
+        parameterModel: IModelWithString = {
             \\"prop\\": \\"Hello World!\\"
         },
     ): Promise<void> {
@@ -1238,9 +1238,9 @@ exports[`v2 should generate: ./test/generated/v2/services/ResponseService.ts 1`]
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { ModelThatExtendsExtends } from './../models/ModelThatExtendsExtends';
-import type { ModelThatExtends } from './../models/ModelThatExtends';
-import type { ModelWithString } from './../models/ModelWithString';
+import type { TModelThatExtendsExtends } from './../models/ModelThatExtendsExtends';
+import type { TModelThatExtends } from './../models/ModelThatExtends';
+import type { IModelWithString } from './../models/ModelWithString';
 import { request as __request } from './../core/request';
 import type { ApiRequestOptions } from './../core/ApiRequestOptions';
 import { OpenAPI } from './../core/OpenAPI';
@@ -1286,36 +1286,36 @@ export const ResponseServiceOptions: TResponseServiceOptions = {
 export class ResponseService {
 
     /**
-     * @returns ModelWithString Message for default response
+     * @returns IModelWithString Message for default response
      * @throws ApiError
      */
-    public static callWithResponse(): Promise<ModelWithString> {
-        return __request<ModelWithString>(ResponseServiceOptions.callWithResponse());
+    public static callWithResponse(): Promise<IModelWithString> {
+        return __request<IModelWithString>(ResponseServiceOptions.callWithResponse());
     }
     /**
-     * @returns ModelWithString Message for default response
+     * @returns IModelWithString Message for default response
      * @throws ApiError
      */
-    public static callWithDuplicateResponses(): Promise<ModelWithString> {
-        return __request<ModelWithString>(ResponseServiceOptions.callWithDuplicateResponses());
+    public static callWithDuplicateResponses(): Promise<IModelWithString> {
+        return __request<IModelWithString>(ResponseServiceOptions.callWithDuplicateResponses());
     }
     /**
      * @returns any Message for 200 response
-     * @returns ModelWithString Message for default response
-     * @returns ModelThatExtends Message for 201 response
-     * @returns ModelThatExtendsExtends Message for 202 response
+     * @returns IModelWithString Message for default response
+     * @returns TModelThatExtends Message for 201 response
+     * @returns TModelThatExtendsExtends Message for 202 response
      * @throws ApiError
      */
     public static callWithResponses(): Promise<{
         readonly '@namespace.string'?: string,
         readonly '@namespace.integer'?: number,
-        readonly value?: Array<ModelWithString>,
-    } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends> {
+        readonly value?: Array<IModelWithString>,
+    } | IModelWithString | TModelThatExtends | TModelThatExtendsExtends> {
         return __request<{
             readonly '@namespace.string'?: string,
             readonly '@namespace.integer'?: number,
-            readonly value?: Array<ModelWithString>,
-        } | ModelWithString | ModelThatExtends | ModelThatExtendsExtends>(ResponseServiceOptions.callWithResponses());
+            readonly value?: Array<IModelWithString>,
+        } | IModelWithString | TModelThatExtends | TModelThatExtendsExtends>(ResponseServiceOptions.callWithResponses());
     }
 }"
 `;
@@ -1324,10 +1324,10 @@ exports[`v2 should generate: ./test/generated/v2/services/Service.ts 1`] = `
 "/* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { DictionaryWithReference } from './../models/DictionaryWithReference';
-import type { ModelWithArray } from './../models/ModelWithArray';
-import type { ModelWithDictionary } from './../models/ModelWithDictionary';
-import type { ModelWithEnumInteger } from './../models/ModelWithEnumInteger';
+import type { IDictionaryWithReference } from './../models/DictionaryWithReference';
+import type { IModelWithArray } from './../models/ModelWithArray';
+import type { IModelWithDictionary } from './../models/ModelWithDictionary';
+import type { IModelWithEnumInteger } from './../models/ModelWithEnumInteger';
 import { request as __request } from './../core/request';
 import type { ApiRequestOptions } from './../core/ApiRequestOptions';
 import { OpenAPI } from './../core/OpenAPI';
@@ -1370,32 +1370,32 @@ export const ServiceOptions: TServiceOptions = {
 export class Service {
 
     /**
-     * @returns DictionaryWithReference Message for default response
+     * @returns IDictionaryWithReference Message for default response
      * @throws ApiError
      */
-    public static getCallWithModelWithDictionaryReference(): Promise<DictionaryWithReference> {
-        return __request<DictionaryWithReference>(ServiceOptions.getCallWithModelWithDictionaryReference());
+    public static getCallWithModelWithDictionaryReference(): Promise<IDictionaryWithReference> {
+        return __request<IDictionaryWithReference>(ServiceOptions.getCallWithModelWithDictionaryReference());
     }
     /**
-     * @returns ModelWithDictionary Message for default response
+     * @returns IModelWithDictionary Message for default response
      * @throws ApiError
      */
-    public static getCallWithModelWithDictionary(): Promise<ModelWithDictionary> {
-        return __request<ModelWithDictionary>(ServiceOptions.getCallWithModelWithDictionary());
+    public static getCallWithModelWithDictionary(): Promise<IModelWithDictionary> {
+        return __request<IModelWithDictionary>(ServiceOptions.getCallWithModelWithDictionary());
     }
     /**
-     * @returns ModelWithEnumInteger Message for default response
+     * @returns IModelWithEnumInteger Message for default response
      * @throws ApiError
      */
-    public static getCallWithSimpleInteger(): Promise<ModelWithEnumInteger> {
-        return __request<ModelWithEnumInteger>(ServiceOptions.getCallWithSimpleInteger());
+    public static getCallWithSimpleInteger(): Promise<IModelWithEnumInteger> {
+        return __request<IModelWithEnumInteger>(ServiceOptions.getCallWithSimpleInteger());
     }
     /**
-     * @returns ModelWithArray Message for default response
+     * @returns IModelWithArray Message for default response
      * @throws ApiError
      */
-    public static getCallWithModelArray(): Promise<ModelWithArray> {
-        return __request<ModelWithArray>(ServiceOptions.getCallWithModelArray());
+    public static getCallWithModelArray(): Promise<IModelWithArray> {
+        return __request<IModelWithArray>(ServiceOptions.getCallWithModelArray());
     }
 }"
 `;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,10 @@ export declare enum HttpClient {
 export type Options = {
     input: string | Record<string, any>;
     output: string;
+    outputCore?: string;
+    outputServices?: string;
+    outputModels?: string;
+    outputSchemas?: string;
     httpClient?: HttpClient;
     useOptions?: boolean;
     useUnionTypes?: boolean;
@@ -15,8 +19,13 @@ export type Options = {
     exportServices?: boolean;
     exportModels?: boolean;
     exportSchemas?: boolean;
+    clean?: boolean;
     request?: string;
     write?: boolean;
+    interfacePrefix?: string;
+    enumPrefix?: string;
+    typePrefix?: string;
+    useCancelableRequest?: boolean;
 };
 
-export declare function generate(options: Options): Promise<void>;
+export declare function generate(options: Options | Options[]): Promise<void>;


### PR DESCRIPTION
- Fixed the conversion of lines into an array of lines inside the function calculateRelationPath (incoming parameters).
- Fixed typification of generator options used in the function generate.
- Fixed the use of the function of obtaining a relative path of the model.
- Fixed the logic of the getType function to specify version 2.
- Fixed the installation of the prefix for the interface (interfacePrefix).
- Fixed the installation of the prefix for the enum (enumPrefix).
- Fixed the installation of the prefix for the type (typePrefix).

- Updated the unit test for the function getType.
- Updated the class Parser to specify version 2.

- Deleted all unused imports and unused utiliities.