### PR TITLE
PDTCH-80 Fixed  the content of the template to create a file with the service code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2025-05-15
+
+### Fixed
+- Fixed  the content of the template to create a file with the service code.
+- Fixed the file generation path in the unit test (src/index.spec.ts).
+
 ## [0.5.1-rc.3] - 2025-05-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ts-openapi-codegen",
-    "version": "0.5.1-rc.3",
+    "version": "0.5.1",
     "description": "Library that generates Typescript clients based on the OpenAPI specification. It bases on openapi-typescript-codegen",
     "author": "Alexey Zverev",
     "homepage": "https://github.com/ozonophore/openapi-codegen.git",
@@ -79,7 +79,6 @@
         "@babel/preset-env": "7.14.9",
         "@babel/preset-typescript": "7.14.5",
         "@rollup/plugin-commonjs": "20.0.0",
-        "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "13.0.4",
         "@types/axios": "^0.14.0",
         "@types/express": "4.17.13",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,6 @@ const typescript = require('rollup-plugin-typescript2');
 const handlebars = require('handlebars');
 const path = require('path');
 const fs = require('fs');
-const json = require('@rollup/plugin-json');
 
 const pkg = require('./package.json');
 const external = Object.keys(pkg.dependencies);
@@ -49,7 +48,6 @@ const handlebarsPlugin = () => ({
 
 const getPlugins = () => {
     const plugins = [
-        json(),
         nodeResolve(),
         commonjs({
             sourceMap: false,

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -20,7 +20,7 @@ describe('index', () => {
     it('should generate from different files', async () => {
         await OpenAPI.generate({
             input: './test/spec/v3.yml',
-            output: './test/generated/v3_1/',
+            output: './generated/v3_1/',
             write: true,
         });
     });
@@ -61,7 +61,7 @@ describe('index', () => {
     it('should generate object with alias', async () => {
         await OpenAPI.generate({
             input: './test/spec/v3withAlias.yaml',
-            output: './test/generated/v3withAlias/',
+            output: './generated/v3withAlias/',
             httpClient: OpenAPI.HttpClient.FETCH,
             useOptions: false,
             useUnionTypes: false,

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -6,11 +6,11 @@ import type { {{{name}}}{{#if alias}} as {{{alias}}}{{/if}} } from '{{{@root.out
 {{/each}}
 {{/if}}
 {{#if @root.useCancelableRequest}}
-import type { CancelablePromise } from '{{{outputCore}}}CancelablePromise';
+import type { CancelablePromise } from '{{{@root.outputCore}}}CancelablePromise';
 {{/if}}
-import { request as __request } from '{{{outputCore}}}request';
-import type { ApiRequestOptions } from '{{{outputCore}}}ApiRequestOptions';
-import { OpenAPI } from '{{{outputCore}}}OpenAPI';
+import { request as __request } from '{{{@root.outputCore}}}request';
+import type { ApiRequestOptions } from '{{{@root.outputCore}}}ApiRequestOptions';
+import { OpenAPI } from '{{{@root.outputCore}}}OpenAPI';
 
 {{#each operations}}
 const {{{name}}} = ({{>parameters}}): ApiRequestOptions => ({
@@ -57,11 +57,11 @@ export class {{{name}}} {
      * @throws ApiError
      */
     {{#if @root.useCancelableRequest}}
-    public static {{{name}}}({{>parameters}}): CancelablePromise<{{>result}}> {
+    public static {{{name}}}({{>parameters}}): CancelablePromise<{{>result default="void"}}> {
     {{else}}
-    public static {{{name}}}({{>parameters}}): Promise<{{>result}}> {
+    public static {{{name}}}({{>parameters}}): Promise<{{>result default="void"}}> {
     {{/if}}
-        return __request<{{>result}}>({{../originName}}Options.{{{name}}}({{>parameterValues~}}), OpenAPI);
+        return __request<{{>result default="void"}}>({{../originName}}Options.{{{name}}}({{>parameterValues~}}), OpenAPI);
     }
     {{/each}}
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -14,7 +14,7 @@ export function format(input: string): string {
             arrowParens: 'avoid',
             endOfLine: 'auto',
         });
-    
+
         return formatedCode;
     } catch {
         throw new Error('Could not to format the value via prettier');

--- a/src/utils/writeClient.ts
+++ b/src/utils/writeClient.ts
@@ -115,7 +115,6 @@ export class WriteClient {
      */
     async writeClient(options: IWriteClient): Promise<void> {
         const { client, templates, outputPaths, httpClient, useOptions, useUnionTypes, exportCore, exportServices, exportModels, exportSchemas, request, useCancelableRequest = false } = options;
-        // const { output, outputCore, outputModels, outputSchemas, outputServices } = outputPaths;
 
         if (exportCore) {
             await mkdir(outputPaths.outputCore);


### PR DESCRIPTION
Previous code edits have made it possible to identify hidden errors:
1) incorrectly compiled template for the service;
2) error in the unit test.